### PR TITLE
Updating stalebot from v1 to v4

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v1
+    - uses: actions/stale@v4
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: ':wave: Hi! This issue has been marked stale due to inactivity. If no further activity occurs, it will automatically be closed.'


### PR DESCRIPTION
Signed-off-by: Upkar Lidder <ulidder@us.ibm.com>

@sforsyth089 I just noticed we are using a very old version of the stalebot. Maybe that's why it was not working as expected. Updated from v1 to v4.
