### PR TITLE
use string for attorneyID and added int tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,7 +289,7 @@
 						</goals>
 						<configuration>
 							<includes>
-								<include>**/it/**</include>
+								<include>**/it/*IT.java</include>
 							</includes>
 							<systemPropertyVariables>
 								<liberty.test.port>${testServerHttpPort}</liberty.test.port>

--- a/src/main/java/application/model/AttorneyModel.java
+++ b/src/main/java/application/model/AttorneyModel.java
@@ -1,6 +1,14 @@
 package application.model;
 
-import static com.cloudant.client.api.query.Expression.ne;
+import com.cloudant.client.api.ClientBuilder;
+import com.cloudant.client.api.CloudantClient;
+import com.cloudant.client.api.Database;
+import com.cloudant.client.api.model.Response;
+import com.cloudant.client.api.query.QueryBuilder;
+import com.cloudant.client.api.query.QueryResult;
+import com.google.common.collect.Iterables;
+import io.swagger.model.Attorney;
+import io.swagger.model.ModelCase;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -8,24 +16,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import com.cloudant.client.api.ClientBuilder;
-import com.cloudant.client.api.CloudantClient;
-import com.cloudant.client.api.Database;
-import com.cloudant.client.api.model.Response;
-import com.cloudant.client.api.query.QueryBuilder;
-import com.cloudant.client.api.query.QueryResult;
-
-import io.swagger.model.Attorney;
-import io.swagger.model.CaseReport;
-import io.swagger.model.ModelCase;
+import static com.cloudant.client.api.query.Expression.ne;
 
 public class AttorneyModel {
-//  private CloudantClient client = null;
-	private Database db = null;
+  	private CloudantClient client = null;
+	private final Database db;
 
 	public AttorneyModel(String url, String apiKey, String database) {
 		System.out.println(url);
-		CloudantClient client = null;
 		try {
 			client = ClientBuilder.url(new URL(url)).iamApiKey(apiKey).build();
 		} catch (MalformedURLException e) {
@@ -52,11 +50,15 @@ public class AttorneyModel {
 		return attorney;
 	}
 
+	public String getUuid() {
+		return Iterables.getOnlyElement(client.uuids(1));
+	}
+
 	public Response addCaseToAttorney(String id, ModelCase modelCase) {
 		Attorney attorney = db.find(Attorney.class, id);
 
 		if (attorney.getCases() == null)
-			attorney.setCases(new ArrayList<ModelCase>());
+			attorney.setCases(new ArrayList<>());
 
 		attorney.getCases().add(modelCase);
 		Response response = db.update(attorney);

--- a/src/main/java/io/swagger/api/impl/CaseApiServiceImpl.java
+++ b/src/main/java/io/swagger/api/impl/CaseApiServiceImpl.java
@@ -16,63 +16,69 @@ import io.swagger.model.ModelCase;
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaJerseyServerCodegen", date = "2020-10-13T17:17:47.836Z")
 public class CaseApiServiceImpl extends CaseApiService {
 
-	private AttorneyModel am = null;
+    private AttorneyModel am = null;
 
-	public CaseApiServiceImpl() {
-		String databaseUrl = System.getenv("AGGREGATOR_DB_URL");
-		String databaseIamKey = System.getenv("AGGREGATOR_DB_IAM_KEY");
-		am = new AttorneyModel(databaseUrl, databaseIamKey, "outcarcerate-attorney");
-	}
+    public CaseApiServiceImpl() {
+        String databaseUrl = System.getenv("AGGREGATOR_DB_URL");
+        String databaseIamKey = System.getenv("AGGREGATOR_DB_IAM_KEY");
+        am = new AttorneyModel(databaseUrl, databaseIamKey, "outcarcerate-attorney");
+    }
 
-	@Override
-	public Response addCase(@NotNull String attorneyId, ModelCase body, SecurityContext securityContext)
-			throws NotFoundException {
-		System.out.println("addCase");
-		com.cloudant.client.api.model.Response resp = am.addCaseToAttorney(attorneyId, body);
-		if (resp.getError() == null) {
-			return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, resp.getId())).build();
-		} else {
-			return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.ERROR, resp.getError())).build();
-		}
-	}
+    @Override
+    public Response addCase(@NotNull String attorneyId, ModelCase body, SecurityContext securityContext)
+            throws NotFoundException {
+        System.out.println("addCase");
 
-	@Override
-	public Response deleteCaseById(String attorneyId, String caseId, SecurityContext securityContext)
-			throws NotFoundException {
-		com.cloudant.client.api.model.Response resp = am.deleteCaseFromAttorney(attorneyId, caseId);
-		if (resp.getError() == null) {
-			return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, resp.getId())).build();
-		} else {
-			return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.ERROR, resp.getError())).build();
-		}
-	}
+        String id = body.getId();
+        if (id == null || id.trim().isEmpty()) {
+            body.setId(am.getUuid());
+        }
 
-	@Override
-	public Response getCase(String attorneyId, String caseId, SecurityContext securityContext)
-			throws NotFoundException {
-		System.out.println("getCase");
-		List<ModelCase> qr = am.getCasesByIdForAttorney(attorneyId, caseId);
-		CaseResponse ar = new CaseResponse();
-		ar.setCode(200);
-		ar.setSuccess(true);
-		ar.setClients(qr);
-		return Response.ok().entity(ar).build();
-	}
+        com.cloudant.client.api.model.Response resp = am.addCaseToAttorney(attorneyId, body);
+        if (resp.getError() == null) {
+            return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, resp.getId())).build();
+        } else {
+            return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.ERROR, resp.getError())).build();
+        }
+    }
 
-	@Override
-	public Response getCaseById(String attorneyId, SecurityContext securityContext) throws NotFoundException {
+    @Override
+    public Response deleteCaseById(String attorneyId, String caseId, SecurityContext securityContext)
+            throws NotFoundException {
+        com.cloudant.client.api.model.Response resp = am.deleteCaseFromAttorney(attorneyId, caseId);
+        if (resp.getError() == null) {
+            return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, resp.getId())).build();
+        } else {
+            return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.ERROR, resp.getError())).build();
+        }
+    }
 
-		System.out.println("getCaseById");
-		List<ModelCase> qr = am.getCasesForAttorney(attorneyId);
-		CaseResponse ar = new CaseResponse();
-		ar.setCode(200);
-		ar.setSuccess(true);
-		ar.setClients(qr);
-		return Response.ok().entity(ar).build();
+    @Override
+    public Response getCase(String attorneyId, String caseId, SecurityContext securityContext)
+            throws NotFoundException {
+        System.out.println("getCase");
+        List<ModelCase> qr = am.getCasesByIdForAttorney(attorneyId, caseId);
+        CaseResponse ar = new CaseResponse();
+        ar.setCode(200);
+        ar.setSuccess(true);
+        ar.setClients(qr);
+        return Response.ok().entity(ar).build();
+    }
 
-	}
-	
-	@Override
+    @Override
+    public Response getCaseById(String attorneyId, SecurityContext securityContext) throws NotFoundException {
+
+        System.out.println("getCaseById");
+        List<ModelCase> qr = am.getCasesForAttorney(attorneyId);
+        CaseResponse ar = new CaseResponse();
+        ar.setCode(200);
+        ar.setSuccess(true);
+        ar.setClients(qr);
+        return Response.ok().entity(ar).build();
+
+    }
+
+    @Override
     public Response getCaseReport(String attorneyId, String caseId, SecurityContext securityContext) throws NotFoundException {
         // TODO Implementation to be added based on report-generator outcome
         return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();

--- a/src/main/resources/swagger.yaml
+++ b/src/main/resources/swagger.yaml
@@ -175,7 +175,7 @@ paths:
       parameters:
       - in: query
         name: attorneyId
-        type : integer
+        type : string
         required: true
         description: "Enter the attorney id for which the case to be added"
       - in: "body"

--- a/src/main/webapp/META-INF/openapi.yaml
+++ b/src/main/webapp/META-INF/openapi.yaml
@@ -161,7 +161,7 @@ paths:
           required: true
           description: Enter the attorney id for which the case to be added
           schema:
-            type: integer
+            type: string
       responses:
         '405':
           description: Invalid input

--- a/src/test/java/it/AggregatorConnection.java
+++ b/src/test/java/it/AggregatorConnection.java
@@ -1,0 +1,122 @@
+package it;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+public class AggregatorConnection {
+
+    AggregatorConnection() {
+    }
+
+    public String doGet(String resource) {
+        return doRequest(getUrl(resource),
+                RequestMethod.GET,
+                null);
+    }
+
+    public String doPost(String resource, String data) {
+        return doRequest(getUrl(resource),
+                RequestMethod.POST,
+                data);
+    }
+
+    public String doDelete(String resource) {
+        return doRequest(getUrl(resource),
+                RequestMethod.DELETE,
+                null);
+    }
+
+    private String getUrl(String resource) {
+        return IntegrationTestConstants.URL + "/" + resource;
+    }
+
+    private String doRequest(String urlString,
+                             RequestMethod requestMethod,
+                             String data) {
+
+        HttpURLConnection connection = null;
+        try {
+            connection = openHttpURLConnection(urlString, requestMethod.name());
+            connection.setDoOutput(true);
+
+            if (data != null && !data.trim().isEmpty()) {
+                writeString(connection, data);
+            }
+
+            InputStream inputStream = connection.getInputStream();
+
+            return getString(inputStream);
+        } catch (Exception e) {
+            handleException(connection, e);
+        }
+
+        // Execution would never get to this point but otherwise there's a compile-time error for no return statement.
+        return "";
+    }
+
+    private void handleException(HttpURLConnection connection, Exception e) throws RuntimeException {
+        if (connection != null && connection.getErrorStream() != null) {
+            throw new RuntimeException(e.getMessage() + "\n" + getString(connection.getErrorStream()));
+        } else {
+            throw new RuntimeException(e.getMessage(), e.getCause());
+        }
+    }
+
+    private HttpURLConnection openHttpURLConnection(String urlString, String requestMethod) throws IOException {
+
+        URL url = new URL(urlString);
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.addRequestProperty("Content-Type", "application/json");
+        connection = (HttpURLConnection) url.openConnection();
+        connection.setRequestMethod(requestMethod);
+        connection.setRequestProperty("Accept", "*/*");
+        connection.setRequestProperty("Content-Type", "application/json");
+        connection.setUseCaches(false);
+        connection.setConnectTimeout(20000);
+        connection.setReadTimeout(20000);
+
+        return connection;
+    }
+
+    private void writeString(HttpURLConnection connection, String str) {
+        try (OutputStream os = connection.getOutputStream()) {
+            byte[] inputBytes = str.getBytes(StandardCharsets.UTF_8);
+            os.write(inputBytes, 0, inputBytes.length);
+            os.flush();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String getString(InputStream inputStream) {
+
+        try (ByteArrayOutputStream result = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[1024];
+            int length;
+            while ((length = inputStream.read(buffer)) != -1) {
+                result.write(buffer, 0, length);
+            }
+
+            return result.toString(StandardCharsets.UTF_8.name());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            try {
+                inputStream.close();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private enum RequestMethod {
+        GET,
+        POST,
+        DELETE
+    }
+}

--- a/src/test/java/it/AttorneyIT.java
+++ b/src/test/java/it/AttorneyIT.java
@@ -1,0 +1,104 @@
+package it;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.api.ApiResponseMessage;
+import io.swagger.model.Attorney;
+import io.swagger.model.AttorneyResponse;
+import org.junit.Test;
+
+import static it.IntegrationTestConstants.ATTORNEY_RESOURCE;
+import static org.junit.Assert.*;
+
+public class AttorneyIT {
+
+    private final AggregatorConnection conn = new AggregatorConnection();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void addAttorney_withoutCase_addsAttorney() {
+
+        ApiResponseMessage apiResponseMessage = new TestAttorney.Builder()
+                .withoutCase()
+                .create()
+                .getApiResponseMessage();
+        assertEquals(ApiResponseMessage.OK, apiResponseMessage.getCode());
+        assertNotNull(apiResponseMessage.getMessage());
+    }
+
+    @Test
+    public void addAttorney_withCase_addsAttorney() {
+
+        ApiResponseMessage apiResponseMessage = new TestAttorney.Builder()
+                .withCase()
+                .create()
+                .getApiResponseMessage();
+        assertEquals(ApiResponseMessage.OK, apiResponseMessage.getCode());
+        assertNotNull(apiResponseMessage.getMessage());
+    }
+
+    @Test
+    public void getAllAttorneys_getsAttorney() throws Exception {
+
+        String attorneyId = addAttorney();
+
+        String json = conn.doGet(ATTORNEY_RESOURCE);
+        AttorneyResponse attorneyResponse = objectMapper.readValue(json, AttorneyResponse.class);
+        assertEquals((Integer) 200, attorneyResponse.getCode());
+        assertNull(attorneyResponse.getError());
+        assertNotNull(getAttorney(attorneyResponse, attorneyId));
+    }
+
+    private Attorney getAttorney(String attorneyId) {
+        try {
+            String json = conn.doGet(ATTORNEY_RESOURCE);
+            AttorneyResponse attorneyResponse = objectMapper.readValue(json, AttorneyResponse.class);
+            return getAttorney(attorneyResponse, attorneyId);
+        } catch(JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Attorney getAttorney(AttorneyResponse attorneyResponse, String attorneyId) {
+
+        Attorney result = null;
+        for (Attorney attorney : attorneyResponse.getAttorney()) {
+            if (attorney.getId().equals(attorneyId)) {
+                result = attorney;
+                break;
+            }
+        }
+
+        return result;
+    }
+
+    @Test
+    public void findAttorney_findsAttorney() throws JsonProcessingException {
+
+        String attorneyId = addAttorney();
+
+        String json = conn.doGet(ATTORNEY_RESOURCE + "/" + attorneyId);
+        Attorney attorney = objectMapper.readValue(json, Attorney.class);
+        assertEquals(attorneyId, attorney.getId());
+    }
+
+    @Test
+    public void deleteAttorney_deletesAttorney() throws JsonProcessingException {
+
+        String attorneyId = addAttorney();
+
+        String deleteResponseJson = conn.doDelete(ATTORNEY_RESOURCE + "/" + attorneyId);
+        ApiResponseMessage apiResponseMessage = objectMapper.readValue(deleteResponseJson, ApiResponseMessage.class);
+        assertEquals(ApiResponseMessage.OK, apiResponseMessage.getCode());
+        assertEquals(attorneyId, apiResponseMessage.getMessage());
+
+        assertNull(getAttorney(attorneyId));
+    }
+
+    private String addAttorney() {
+       return new TestAttorney.Builder()
+                .withCase()
+                .create()
+                .getAttorneyId();
+    }
+}

--- a/src/test/java/it/CaseIT.java
+++ b/src/test/java/it/CaseIT.java
@@ -1,0 +1,111 @@
+package it;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Iterables;
+import io.swagger.api.ApiResponseMessage;
+import io.swagger.model.CaseResponse;
+import io.swagger.model.ModelCase;
+import org.junit.Test;
+
+import static it.IntegrationTestConstants.CASE_RESOURCE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class CaseIT {
+
+    private final AggregatorConnection conn = new AggregatorConnection();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void addCase_addsCase() throws JsonProcessingException {
+
+        String attorneyId = addAttorney();
+        String clientId = addClient(attorneyId);
+
+        ApiResponseMessage apiResponseMessage = addCase(attorneyId, clientId);
+
+        assertEquals(ApiResponseMessage.OK, apiResponseMessage.getCode());
+        assertNotNull(apiResponseMessage.getMessage());
+    }
+
+    @Test
+    public void getCases_getsCasesByAttorney() throws JsonProcessingException {
+
+        String attorneyId = addAttorney();
+        String clientId = addClient(attorneyId);
+        addCase(attorneyId, clientId);
+
+        String json = conn.doGet(CASE_RESOURCE + "/" + attorneyId);
+        CaseResponse caseResponse = objectMapper.readValue(json, CaseResponse.class);
+        assertEquals(1, caseResponse.getClients().size());
+        ModelCase modelCase = Iterables.getOnlyElement(caseResponse.getClients());
+        assertEquals(attorneyId, modelCase.getAttorneyId());
+        assertEquals(clientId, modelCase.getClientId());
+    }
+
+    private String addAttorney() {
+
+        TestAttorney testAttorney = new TestAttorney.Builder()
+                .withoutCase()
+                .create();
+        return testAttorney.getAttorneyId();
+    }
+
+    private String addClient(String attorneyId) {
+        return new TestClient.Builder(attorneyId)
+                .create()
+                .getClientId();
+    }
+
+    private ApiResponseMessage addCase(String attorneyId, String clientId) throws JsonProcessingException {
+
+        String json = conn.doPost(CASE_RESOURCE + "?attorneyId=" + attorneyId, getNewCaseJson(attorneyId, clientId));
+        return objectMapper.readValue(json, ApiResponseMessage.class);
+    }
+
+    private String getNewCaseJson(String attorneyId, String clientId) {
+        return "{\n" +
+                "  \"_id\": \"string\",\n" +
+                "  \"_rev\": null,\n" +
+                "  \"client_id\": \"" + clientId + "\",\n" +
+                "  \"attorney_id\": \"" + attorneyId +"\",\n" +
+                "  \"possible_charges\": [\n" +
+                "    {\n" +
+                "      \"_id\": null,\n" +
+                "      \"_rev\": null,\n" +
+                "      \"trial_type\": \"Guilty plea\",\n" +
+                "      \"disposition_charged_class\": \"string\",\n" +
+                "      \"charge_code\": \"Administration of Justice\",\n" +
+                "      \"attempted\": true,\n" +
+                "      \"primary\": true,\n" +
+                "      \"controlled_substance_quantity_level\": 17,\n" +
+                "      \"possible_sentences\": [\n" +
+                "        {\n" +
+                "          \"_id\": null,\n" +
+                "          \"_rev\": null,\n" +
+                "          \"chargeDisposition\": \"BFW\",\n" +
+                "          \"phase\": \"string\",\n" +
+                "          \"sentence_type\": \"Prison Only\",\n" +
+                "          \"commitmentTerm\": 0,\n" +
+                "          \"commitmentUnit\": \"string\",\n" +
+                "          \"commitmentType\": \"string\",\n" +
+                "          \"minimum_incarceration_months\": 0,\n" +
+                "          \"maximum_incarceration_months\": 0,\n" +
+                "          \"probation_term_months\": 0,\n" +
+                "          \"minimum_probation_months\": 0,\n" +
+                "          \"maximum_probation_months\": 0,\n" +
+                "          \"fine_dollars\": 0,\n" +
+                "          \"minimum_fine_dollars\": 0,\n" +
+                "          \"maximum_fine_dollars\": 0,\n" +
+                "          \"community_service_hours\": 0,\n" +
+                "          \"restitution\": \"string\",\n" +
+                "          \"alternative_sentence\": \"string\",\n" +
+                "          \"suspended_sentence\": true\n" +
+                "        }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}";
+    }
+}

--- a/src/test/java/it/ClientIT.java
+++ b/src/test/java/it/ClientIT.java
@@ -1,0 +1,89 @@
+package it;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.api.ApiResponseMessage;
+import io.swagger.model.Client;
+import io.swagger.model.ClientResponse;
+import org.junit.Test;
+
+import static it.IntegrationTestConstants.CLIENT_RESOURCE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ClientIT {
+
+    private final AggregatorConnection conn = new AggregatorConnection();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void addClient_addsClient() {
+
+        ApiResponseMessage apiResponseMessage = new TestClient.Builder(addAttorney())
+                .create()
+                .getApiResponseMessage();
+        assertEquals(ApiResponseMessage.OK, apiResponseMessage.getCode());
+        assertNotNull(apiResponseMessage.getMessage());
+    }
+
+    @Test
+    public void deleteClient_deletesClient() throws JsonProcessingException {
+
+        String clientId = addClient(addAttorney());
+
+        String json = conn.doDelete(CLIENT_RESOURCE + "/" + clientId);
+        ApiResponseMessage apiResponseMessage = objectMapper.readValue(json, ApiResponseMessage.class);
+        assertEquals(ApiResponseMessage.OK, apiResponseMessage.getCode());
+        assertEquals(clientId, apiResponseMessage.getMessage());
+    }
+
+    @Test
+    public void getClients_getClientById() throws JsonProcessingException {
+
+        String clientId = addClient(addAttorney());
+
+        String json = conn.doGet(CLIENT_RESOURCE + "?clientId=" + clientId);
+        Client client = objectMapper.readValue(json, Client.class);
+        assertEquals(clientId, client.getId());
+    }
+
+    @Test
+    public void getClients_getClientByAttorneyId() throws JsonProcessingException {
+
+        String attorneyId = addAttorney();
+        String clientId = addClient(attorneyId);
+
+        String json = conn.doGet(CLIENT_RESOURCE + "?attorneyId=" + attorneyId);
+        ClientResponse clientResponse = objectMapper.readValue(json, ClientResponse.class);
+        assertEquals(200, clientResponse.getCode().intValue());
+        assertEquals(1, clientResponse.getClients().size());
+        assertEquals(clientId, clientResponse.getClients().get(0).getId());
+    }
+
+    @Test
+    public void getClients_getClientByClientIdAndAttorneyId() throws JsonProcessingException {
+
+        String attorneyId = addAttorney();
+        String clientId = addClient(attorneyId);
+
+        String json = conn.doGet(CLIENT_RESOURCE + "/?clientId=" + clientId + "&attorneyId=" + attorneyId);
+        ClientResponse clientResponse = objectMapper.readValue(json, ClientResponse.class);
+        assertEquals(200, clientResponse.getCode().intValue());
+        assertEquals(1, clientResponse.getClients().size());
+        assertEquals(clientId, clientResponse.getClients().get(0).getId());
+    }
+
+    private String addClient(String attorneyId) {
+       return new TestClient.Builder(attorneyId)
+                .create()
+                .getClientId();
+    }
+
+    private String addAttorney() {
+
+        TestAttorney testAttorney = new TestAttorney.Builder()
+                .withoutCase()
+                .create();
+        return testAttorney.getAttorneyId();
+    }
+}

--- a/src/test/java/it/IntegrationTestConstants.java
+++ b/src/test/java/it/IntegrationTestConstants.java
@@ -1,0 +1,14 @@
+package it;
+
+public class IntegrationTestConstants {
+
+    private static final String SCHEME = "http";
+    private static final String DOMAIN = "localhost";
+    private static final String PORT = "9080";
+    private static final String VERSION = "v1";
+    static final String URL = SCHEME + "://" + DOMAIN + ":" + PORT + "/" + VERSION;
+
+    static final String ATTORNEY_RESOURCE = "attorney";
+    static final String CLIENT_RESOURCE = "client";
+    static final String CASE_RESOURCE = "case";
+}

--- a/src/test/java/it/TestAttorney.java
+++ b/src/test/java/it/TestAttorney.java
@@ -1,0 +1,121 @@
+package it;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.api.ApiResponseMessage;
+
+import static it.IntegrationTestConstants.ATTORNEY_RESOURCE;
+
+public class TestAttorney {
+
+    private final String attorneyId;
+    private final ApiResponseMessage apiResponseMessage;
+
+    private TestAttorney(ApiResponseMessage apiResponseMessage) {
+        this.attorneyId = apiResponseMessage.getMessage();
+        this.apiResponseMessage = apiResponseMessage;
+    }
+
+    public String getAttorneyId() {
+        return attorneyId;
+    }
+
+    public ApiResponseMessage getApiResponseMessage() {
+        return apiResponseMessage;
+    }
+
+    @Override
+    public String toString() {
+        return "TestAttorney{" +
+                "attorneyId='" + attorneyId + '\'' +
+                ", apiResponseMessage=" + apiResponseMessage +
+                '}';
+    }
+
+    public static class Builder {
+
+        private String json = "";
+
+        public Builder() {}
+
+        public Builder withoutCase() {
+            json = "{\n" +
+                    "  \"_id\": null,\n" +
+                    "  \"_rev\": null,\n" +
+                    "  \"username\": \"string\",\n" +
+                    "  \"cases\": null\n" +
+                    "}";
+
+            return this;
+        }
+
+        public Builder withCase() {
+            json = "{\n" +
+                    "  \"_id\": null,\n" +
+                    "  \"_rev\": null,\n" +
+                    "  \"username\": \"string\",\n" +
+                    "  \"cases\": [\n" +
+                    "    {\n" +
+                    "      \"_id\": null,\n" +
+                    "      \"_rev\": null,\n" +
+                    "      \"client_id\": \"string\",\n" +
+                    "      \"attorney_id\": \"string\",\n" +
+                    "      \"possible_charges\": [\n" +
+                    "        {\n" +
+                    "          \"_id\": null,\n" +
+                    "          \"_rev\": null,\n" +
+                    "          \"trial_type\": \"Guilty plea\",\n" +
+                    "          \"disposition_charged_class\": \"string\",\n" +
+                    "          \"charge_code\": \"Administration of Justice\",\n" +
+                    "          \"attempted\": true,\n" +
+                    "          \"primary\": true,\n" +
+                    "          \"controlled_substance_quantity_level\": 17,\n" +
+                    "          \"possible_sentences\": [\n" +
+                    "            {\n" +
+                    "              \"_id\": null,\n" +
+                    "              \"_rev\": null,\n" +
+                    "              \"chargeDisposition\": \"BFW\",\n" +
+                    "              \"phase\": \"string\",\n" +
+                    "              \"sentence_type\": \"Prison Only\",\n" +
+                    "              \"commitmentTerm\": 0,\n" +
+                    "              \"commitmentUnit\": \"string\",\n" +
+                    "              \"commitmentType\": \"string\",\n" +
+                    "              \"minimum_incarceration_months\": 0,\n" +
+                    "              \"maximum_incarceration_months\": 0,\n" +
+                    "              \"probation_term_months\": 0,\n" +
+                    "              \"minimum_probation_months\": 0,\n" +
+                    "              \"maximum_probation_months\": 0,\n" +
+                    "              \"fine_dollars\": 0,\n" +
+                    "              \"minimum_fine_dollars\": 0,\n" +
+                    "              \"maximum_fine_dollars\": 0,\n" +
+                    "              \"community_service_hours\": 0,\n" +
+                    "              \"restitution\": \"string\",\n" +
+                    "              \"alternative_sentence\": \"string\",\n" +
+                    "              \"suspended_sentence\": true\n" +
+                    "            }\n" +
+                    "          ]\n" +
+                    "        }\n" +
+                    "      ]\n" +
+                    "    }\n" +
+                    "  ]\n" +
+                    "}";
+
+            return this;
+        }
+
+        public TestAttorney create() {
+            try {
+                if(json.isEmpty()) {
+                    throw new RuntimeException("json must be set");
+                }
+
+                String jsonResponse = new AggregatorConnection().doPost(ATTORNEY_RESOURCE, json);
+                ApiResponseMessage apiResponseMessage = new ObjectMapper().readValue(jsonResponse, ApiResponseMessage.class);
+                return new TestAttorney(apiResponseMessage);
+            } catch(JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+    }
+}

--- a/src/test/java/it/TestClient.java
+++ b/src/test/java/it/TestClient.java
@@ -1,0 +1,71 @@
+package it;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.api.ApiResponseMessage;
+
+import static it.IntegrationTestConstants.CLIENT_RESOURCE;
+
+public class TestClient {
+
+    private final String clientId;
+    private final String attorneyId;
+    private final ApiResponseMessage apiResponseMessage;
+
+    private TestClient(String attorneyId, ApiResponseMessage apiResponseMessage) {
+        this.clientId = apiResponseMessage.getMessage();
+        this.attorneyId = attorneyId;
+        this.apiResponseMessage = apiResponseMessage;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public String getAttorneyId() {
+        return attorneyId;
+    }
+
+    public ApiResponseMessage getApiResponseMessage() {
+        return apiResponseMessage;
+    }
+
+    @Override
+    public String toString() {
+        return "TestClient{" +
+                "clientId='" + clientId + '\'' +
+                ", apiResponseMessage=" + apiResponseMessage +
+                '}';
+    }
+
+    public static class Builder {
+
+        private final String attorneyId;
+        private final String json;
+
+        public Builder(String attorneyId) {
+
+            this.attorneyId = attorneyId;
+
+            json = "{\n" +
+                    "  \"_id\": null,\n" +
+                    "  \"_rev\": null,\n" +
+                    "  \"attorney_id\": \"" + attorneyId + "\",\n" +
+                    "  \"race\": \"White\",\n" +
+                    "  \"gender\": \"Female\",\n" +
+                    "  \"criminal_history_category\": \"Category I\"\n" +
+                    "}";
+        }
+
+        public TestClient create() {
+            try {
+                String jsonResponse = new AggregatorConnection().doPost(CLIENT_RESOURCE, json);
+                ApiResponseMessage apiResponseMessage = new ObjectMapper().readValue(jsonResponse, ApiResponseMessage.class);
+                return new TestClient(attorneyId, apiResponseMessage);
+            } catch(JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Contributes to # (add issue number here. i.e. `#44`)

## What did you do?
Fixed a bug in the openApi spec where the attorneyID should be a string rather than an integer.
Set the id for a case if it hasn't been set because some operations depend on the id and it's not set automatically.
Added integration tests for testing the attorney, client, and case endpoints.
## Why did you do it?
Having integration tests allows us to quickly to regression testing.
## How have you tested it?
All integration tests were run, as well as running 'mvn verify' on the command line to validate that the correct test classes are run.
## Were docs updated if needed?

- [] No
- [ ] Yes
- [x] N/A

#### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new console logs
- [ ] Fixes entire issue
- [x] Partial fix for issue
